### PR TITLE
[fix] Missing PY_SSIZE_T_CLEAN macro added

### DIFF
--- a/py_sg.c
+++ b/py_sg.c
@@ -4,12 +4,14 @@
  *
  * Copyright (C) 2008 by Daniel Lenski <lenski@umd.edu>
  * Time-stamp: <2008-09-19 00:18:51 dlenski>
- * 
+ *
  * Migrated to Python3 by crypto-universe <ykp@protonmail.ch>
  *
  * Released under the terms of the
  * GNU General Public License version 2 or later
  */
+
+#define PY_SSIZE_T_CLEAN
 
 #include <Python.h>
 
@@ -75,7 +77,7 @@ sg_write(PyObject *self, PyObject *args)
   io.timeout = timeout;   /* in millisecs */
   /* io.flags = 0; */     /* take defaults: indirect IO, etc */
   /* io.pack_id = 0; */
-  /* io.usr_ptr = NULL; */  
+  /* io.usr_ptr = NULL; */
 
   r = ioctl(sg_fd, SG_IO, &io);
 
@@ -89,7 +91,7 @@ sg_write(PyObject *self, PyObject *args)
                     Py_BuildValue("BBBs#", io.masked_status, io.host_status, io.driver_status, sense, io.sb_len_wr));
     return NULL;
   }
-  
+
   Py_RETURN_NONE;
 }
 
@@ -136,7 +138,7 @@ sg_read_into_buf(PyObject *self, PyObject *args)
   io.timeout = timeout;   /* in millisecs */
   /* io.flags = 0; */     /* take defaults: indirect IO, etc */
   /* io.pack_id = 0; */
-  /* io.usr_ptr = NULL; */  
+  /* io.usr_ptr = NULL; */
 
   r = ioctl(sg_fd, SG_IO, &io);
 
@@ -175,7 +177,7 @@ sg_read_as_bin_str(PyObject *self, PyObject *args)
   Py_ssize_t cmdLen, bufLen;
 
   // parse and check arguments
-  
+
   if (!PyArg_ParseTuple(args, "O&s#n|i:read_as_bin_str", obj_to_fd, &sg_fd, &cmd, &cmdLen, &bufLen, &timeout))
     return NULL;
 
@@ -206,7 +208,7 @@ sg_read_as_bin_str(PyObject *self, PyObject *args)
   io.timeout = timeout;   /* in millisecs */
   /* io.flags = 0; */     /* take defaults: indirect IO, etc */
   /* io.pack_id = 0; */
-  /* io.usr_ptr = NULL; */  
+  /* io.usr_ptr = NULL; */
 
   r = ioctl(sg_fd, SG_IO, &io);
 
@@ -244,11 +246,11 @@ static PyMethodDef SgMethods[] = {
   {NULL, NULL, 0, NULL}
 };
 
-static struct PyModuleDef py_sg_definition = { 
+static struct PyModuleDef py_sg_definition = {
     PyModuleDef_HEAD_INIT,
     "py_sg",
     module__doc__,
-    -1, 
+    -1,
     SgMethods
 };
 
@@ -259,7 +261,7 @@ PyInit_py_sg(void)
   Py_Initialize();
   PyMODINIT_FUNC mod = PyModule_Create(&py_sg_definition);
   if (!mod) return NULL;
-  
+
   // SCSIError
   PyObject *doc = Py_BuildValue("{ss}", "__doc__", SCSIError__doc__);
   SCSIError = PyErr_NewException( "py_sg.SCSIError", NULL, doc);

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from distutils.core import setup, Extension
 setup(name = "py_sg",
-      version = "0.13",
+      version = "0.14",
       ext_modules=[
         Extension("py_sg", ["py_sg.c"])
         ],
@@ -21,4 +21,4 @@ will be raised.''',
       url = 'http://tonquil.homeip.net/~dlenski/py_sg',
       license = 'GPLv3',
       classifiers = ['Topic :: System :: Hardware'],
-)                                                                                                  
+)


### PR DESCRIPTION
[WD Passport Utils](https://github.com/0-duke/wdpassport-utils) (uses py_sg) wasn't working for me for newer Python 3 versions, where the macro is mandatory if using '#' formats, so I fixed it.

Reference: https://docs.python.org/3/c-api/arg.html#arg-parsing